### PR TITLE
fix race condition on rho

### DIFF
--- a/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
@@ -526,7 +526,7 @@ void PairMultiLucyRXKokkos<DeviceType>::operator()(TagPairMultiLucyRXComputeLoca
   const double ytmp = x(i,1);
   const double ztmp = x(i,2);
 
-  double rho_i = rho[i];
+  double rho_i_contrib = 0.0;
 
   const int itype = type[i];
   const int jnum = d_numneigh[i];
@@ -549,7 +549,7 @@ void PairMultiLucyRXKokkos<DeviceType>::operator()(TagPairMultiLucyRXComputeLoca
         const double tmpFactor = 1.0 - r_over_rcut;
         const double tmpFactor4 = tmpFactor*tmpFactor*tmpFactor*tmpFactor;
         const double factor = factor_type11*(1.0 + 1.5*r_over_rcut)*tmpFactor4;
-        rho_i += factor;
+        rho_i_contrib += factor;
         if (NEWTON_PAIR || j < nlocal)
           a_rho[j] += factor;
       } else if (rsq < d_cutsq(itype,jtype)) {
@@ -557,14 +557,14 @@ void PairMultiLucyRXKokkos<DeviceType>::operator()(TagPairMultiLucyRXComputeLoca
         const double tmpFactor = 1.0-sqrt(rsq)/rcut;
         const double tmpFactor4 = tmpFactor*tmpFactor*tmpFactor*tmpFactor;
         const double factor = (84.0/(5.0*pi*rcut*rcut*rcut))*(1.0+3.0*sqrt(rsq)/(2.0*rcut))*tmpFactor4;
-        rho_i += factor;
+        rho_i_contrib += factor;
         if (NEWTON_PAIR || j < nlocal)
           a_rho[j] += factor;
       }
     }
   }
 
-  a_rho[i] = rho_i;
+  a_rho[i] += rho_i_contrib;
 }
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
the main bug here is the use of a local
rho_i accumulator which later gets assigned
back to rho[i].
in parallel, atomic additions can happen to
rho[i] while the local accumulator is held;
those atomic additions are lost when
the accumulator is atomically assigned.
we instead initialize the accumulator to zero
and atomically add it back to rho[i].

@stanmoore1 