### PR TITLE
pair_table_rx_kokkos

### DIFF
--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -28,8 +28,8 @@ action () {
 
 # force rebuild of files with LMP_KOKKOS switch
 
-#touch ../accelerator_kokkos.h
-#touch ../memory.h
+touch ../accelerator_kokkos.h
+touch ../memory.h
 
 # list of files with optional dependcies
 
@@ -196,7 +196,7 @@ action pair_vashishta_kokkos.h pair_vashishta.h
 action pair_table_kokkos.cpp
 action pair_table_kokkos.h
 action pair_table_rx_kokkos.cpp pair_table_rx.cpp
-action pair_table_rx_kokkos.h pair_table_rx.h  
+action pair_table_rx_kokkos.h pair_table_rx.h
 action pair_tersoff_kokkos.cpp pair_tersoff.cpp
 action pair_tersoff_kokkos.h pair_tersoff.h
 action pair_tersoff_mod_kokkos.cpp pair_tersoff_mod.cpp

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -195,8 +195,8 @@ action pair_vashishta_kokkos.cpp pair_vashishta.cpp
 action pair_vashishta_kokkos.h pair_vashishta.h
 action pair_table_kokkos.cpp
 action pair_table_kokkos.h
-#action pair_table_rx_kokkos.cpp pair_table_rx.cpp
-#action pair_table_rx_kokkos.h pair_table_rx.h  
+action pair_table_rx_kokkos.cpp pair_table_rx.cpp
+action pair_table_rx_kokkos.h pair_table_rx.h  
 action pair_tersoff_kokkos.cpp pair_tersoff.cpp
 action pair_tersoff_kokkos.h pair_tersoff.h
 action pair_tersoff_mod_kokkos.cpp pair_tersoff_mod.cpp

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -28,8 +28,8 @@ action () {
 
 # force rebuild of files with LMP_KOKKOS switch
 
-touch ../accelerator_kokkos.h
-touch ../memory.h
+#touch ../accelerator_kokkos.h
+#touch ../memory.h
 
 # list of files with optional dependcies
 

--- a/src/KOKKOS/neigh_list_kokkos.h
+++ b/src/KOKKOS/neigh_list_kokkos.h
@@ -90,7 +90,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   static AtomNeighborsConst static_neighbors_const(int i,
            typename ArrayTypes<Device>::t_neighbors_2d_const d_neighbors,
-           typename ArrayTypes<Device>::t_int_1d d_numneigh) {
+           typename ArrayTypes<Device>::t_int_1d_const d_numneigh) {
     return AtomNeighborsConst(&d_neighbors(i,0),d_numneigh(i),
                               &d_neighbors(i,1)-&d_neighbors(i,0));
   }

--- a/src/KOKKOS/neigh_list_kokkos.h
+++ b/src/KOKKOS/neigh_list_kokkos.h
@@ -48,7 +48,7 @@ class AtomNeighborsConst
   const int num_neighs;
 
   KOKKOS_INLINE_FUNCTION
-  AtomNeighborsConst(int* const & firstneigh, const int & _num_neighs,
+  AtomNeighborsConst(const int* const & firstneigh, const int & _num_neighs,
                      const int & stride):
   _firstneigh(firstneigh), num_neighs(_num_neighs), _stride(stride) {};
   KOKKOS_INLINE_FUNCTION
@@ -85,6 +85,14 @@ public:
   AtomNeighbors get_neighbors(const int &i) const {
     return AtomNeighbors(&d_neighbors(i,0),d_numneigh(i),
                          &d_neighbors(i,1)-&d_neighbors(i,0));
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static AtomNeighborsConst static_neighbors_const(int i,
+           typename ArrayTypes<Device>::t_neighbors_2d_const d_neighbors,
+           typename ArrayTypes<Device>::t_int_1d d_numneigh) {
+    return AtomNeighborsConst(&d_neighbors(i,0),d_numneigh(i),
+                              &d_neighbors(i,1)-&d_neighbors(i,0));
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -179,20 +179,6 @@ void PairTableRXKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
     compute_style<BITMAP>(eflag_in,vflag_in);
 }
 
-template<class DeviceType>
-template <int NEIGHFLAG, bool STACKPARAMS, int TABSTYLE>
-PairTableRXKokkos<DeviceType>::Functor<NEIGHFLAG,STACKPARAMS,TABSTYLE>::Functor(
-    PairTableRXKokkos* c_ptr, NeighListKokkos<DeviceType>* list_ptr)//:
-//c(*c_ptr),f(c.f),uCG(c.uCG),uCGnew(c.uCGnew),list(*list_ptr)
-{}
-
-template<class DeviceType>
-template <int NEIGHFLAG, bool STACKPARAMS, int TABSTYLE>
-PairTableRXKokkos<DeviceType>::Functor<NEIGHFLAG,STACKPARAMS,TABSTYLE>::~Functor() {
-//c.cleanup_copy();
-//list.clean_copy();
-}
-
 KOKKOS_INLINE_FUNCTION static int sbmask(const int& j)
 {
   return j >> SBBITS & 3;

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -53,8 +53,9 @@ PairTableRXKokkos<DeviceType>::PairTableRXKokkos(LAMMPS *lmp) : PairTable(lmp)
   update_table = 0;
   atomKK = (AtomKokkos *) atom;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
-  datamask_read = X_MASK | F_MASK | TYPE_MASK | ENERGY_MASK | VIRIAL_MASK | DVECTOR_MASK;
-  datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+  datamask_read = X_MASK | F_MASK | TYPE_MASK | ENERGY_MASK | VIRIAL_MASK |
+                  DVECTOR_MASK | UCG_MASK | UCGNEW_MASK;
+  datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK | UCG_MASK | UCGNEW_MASK;
   h_table = new TableHost();
   d_table = new TableDevice();
   fractionalWeighting = true;
@@ -94,7 +95,7 @@ template<class DeviceType>
 template <int NEIGHFLAG, bool STACKPARAMS, int TABSTYLE>
 PairTableRXKokkos<DeviceType>::Functor<NEIGHFLAG,STACKPARAMS,TABSTYLE>::Functor(
     PairTableRXKokkos* c_ptr, NeighListKokkos<device_type>* list_ptr):
-  c(*c_ptr),f(c.f),list(*list_ptr)
+  c(*c_ptr),f(c.f),uCG(c.uCG),uCGnew(c.uCGnew),list(*list_ptr)
 {}
 
 template<class DeviceType>
@@ -301,6 +302,8 @@ void PairTableRXKokkos<DeviceType>::compute_style(int eflag_in, int vflag_in)
   x = c_x = atomKK->k_x.view<DeviceType>();
   f = atomKK->k_f.view<DeviceType>();
   type = atomKK->k_type.view<DeviceType>();
+  uCG = atomKK->k_uCG.view<DeviceType>();
+  uCGnew = atomKK->k_uCGnew.view<DeviceType>();
   nlocal = atom->nlocal;
   nall = atom->nlocal + atom->nghost;
   special_lj[0] = force->special_lj[0];

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -527,7 +527,10 @@ void PairTableRXKokkos<DeviceType>::cleanup_copy() {
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
-void PairTableRXKokkos<DeviceType>::getMixingWeights(typename DAT::t_float_2d_randomread dvector, int, double &, double &, double &, double &) {
+void PairTableRXKokkos<DeviceType>::getMixingWeights(
+    typename DAT::t_float_2d_randomread dvector, int id,
+    double &mixWtSite1old, double &mixWtSite2old,
+    double &mixWtSite1, double &mixWtSite2) {
   double fractionOFAold, fractionOFA;
   double fractionOld1, fraction1;
   double fractionOld2, fraction2;

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -410,7 +410,7 @@ compute_item(
         f(j,2) -= delz*fpair;
       }
 
-      auto evdwl = compute_evdwl<STACKPARAMS,TABSTYLE>(
+      auto evdwl = compute_evdwl<DeviceType,TABSTYLE>(
           rsq,itype,jtype,d_table_const);
 
       double evdwlOld;

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -94,15 +94,15 @@ void PairTableRXKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 template<class DeviceType>
 template <int NEIGHFLAG, bool STACKPARAMS, int TABSTYLE>
 PairTableRXKokkos<DeviceType>::Functor<NEIGHFLAG,STACKPARAMS,TABSTYLE>::Functor(
-    PairTableRXKokkos* c_ptr, NeighListKokkos<device_type>* list_ptr):
-  c(*c_ptr),f(c.f),uCG(c.uCG),uCGnew(c.uCGnew),list(*list_ptr)
+    PairTableRXKokkos* c_ptr, NeighListKokkos<device_type>* list_ptr)//:
+//c(*c_ptr),f(c.f),uCG(c.uCG),uCGnew(c.uCGnew),list(*list_ptr)
 {}
 
 template<class DeviceType>
 template <int NEIGHFLAG, bool STACKPARAMS, int TABSTYLE>
 PairTableRXKokkos<DeviceType>::Functor<NEIGHFLAG,STACKPARAMS,TABSTYLE>::~Functor() {
-  c.cleanup_copy();
-  list.clean_copy();
+//c.cleanup_copy();
+//list.clean_copy();
 }
 
 template<class DeviceType>
@@ -113,89 +113,89 @@ EV_FLOAT
 PairTableRXKokkos<DeviceType>::Functor<NEIGHFLAG,STACKPARAMS,TABSTYLE>::
 compute_item(const int& ii) const {
   EV_FLOAT ev;
-  const int i = list.d_ilist[ii];
-  const X_FLOAT xtmp = c.x(i,0);
-  const X_FLOAT ytmp = c.x(i,1);
-  const X_FLOAT ztmp = c.x(i,2);
-  const int itype = c.type(i);
+//const int i = list.d_ilist[ii];
+//const X_FLOAT xtmp = c.x(i,0);
+//const X_FLOAT ytmp = c.x(i,1);
+//const X_FLOAT ztmp = c.x(i,2);
+//const int itype = c.type(i);
 
-  const AtomNeighborsConst jlist = list.get_neighbors_const(i);
-  const int jnum = list.d_numneigh[i];
+//const AtomNeighborsConst jlist = list.get_neighbors_const(i);
+//const int jnum = list.d_numneigh[i];
 
-  double uCG_i = 0.0;
-  double uCGnew_i = 0.0;
-  double fx_i = 0.0, fy_i = 0.0, fz_i = 0.0;
+//double uCG_i = 0.0;
+//double uCGnew_i = 0.0;
+//double fx_i = 0.0, fy_i = 0.0, fz_i = 0.0;
 
-  double mixWtSite1old_i = c.mixWtSite1old_(i);
-  double mixWtSite2old_i = c.mixWtSite2old_(i);
-  double mixWtSite1_i = c.mixWtSite1_(i);
-  double mixWtSite2_i = c.mixWtSite2_(i);
+//double mixWtSite1old_i = c.mixWtSite1old_(i);
+//double mixWtSite2old_i = c.mixWtSite2old_(i);
+//double mixWtSite1_i = c.mixWtSite1_(i);
+//double mixWtSite2_i = c.mixWtSite2_(i);
 
-  for (int jj = 0; jj < jnum; jj++) {
-    int j = jlist(jj);
-    const F_FLOAT factor_lj = c.special_lj[sbmask(j)];
-    j &= NEIGHMASK;
+//for (int jj = 0; jj < jnum; jj++) {
+//  int j = jlist(jj);
+//  const F_FLOAT factor_lj = c.special_lj[sbmask(j)];
+//  j &= NEIGHMASK;
 
-    const X_FLOAT delx = xtmp - c.x(j,0);
-    const X_FLOAT dely = ytmp - c.x(j,1);
-    const X_FLOAT delz = ztmp - c.x(j,2);
-    const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
-    const int jtype = c.type(j);
+//  const X_FLOAT delx = xtmp - c.x(j,0);
+//  const X_FLOAT dely = ytmp - c.x(j,1);
+//  const X_FLOAT delz = ztmp - c.x(j,2);
+//  const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
+//  const int jtype = c.type(j);
 
-    if(rsq < (STACKPARAMS?c.m_cutsq[itype][jtype]:c.d_cutsq(itype,jtype))) {
-      double mixWtSite1old_j = c.mixWtSite1old_(j);
-      double mixWtSite2old_j = c.mixWtSite2old_(j);
-      double mixWtSite1_j = c.mixWtSite1_(j);
-      double mixWtSite2_j = c.mixWtSite2_(j);
+//  if(rsq < (STACKPARAMS?c.m_cutsq[itype][jtype]:c.d_cutsq(itype,jtype))) {
+//    double mixWtSite1old_j = c.mixWtSite1old_(j);
+//    double mixWtSite2old_j = c.mixWtSite2old_(j);
+//    double mixWtSite1_j = c.mixWtSite1_(j);
+//    double mixWtSite2_j = c.mixWtSite2_(j);
 
-      const F_FLOAT fpair = factor_lj*c.template compute_fpair<STACKPARAMS,TABSTYLE>(rsq,i,j,itype,jtype);
+//    const F_FLOAT fpair = factor_lj*c.template compute_fpair<STACKPARAMS,TABSTYLE>(rsq,i,j,itype,jtype);
 
-      fx_i += delx*fpair;
-      fy_i += dely*fpair;
-      fz_i += delz*fpair;
+//    fx_i += delx*fpair;
+//    fy_i += dely*fpair;
+//    fz_i += delz*fpair;
 
-      bool do_half = (NEIGHFLAG==HALF || NEIGHFLAG==HALFTHREAD) &&
-                     (NEWTON_PAIR || j < c.nlocal);
-      if (do_half) {
-        f(j,0) -= delx*fpair;
-        f(j,1) -= dely*fpair;
-        f(j,2) -= delz*fpair;
-      }
+//    bool do_half = (NEIGHFLAG==HALF || NEIGHFLAG==HALFTHREAD) &&
+//                   (NEWTON_PAIR || j < c.nlocal);
+//    if (do_half) {
+//      f(j,0) -= delx*fpair;
+//      f(j,1) -= dely*fpair;
+//      f(j,2) -= delz*fpair;
+//    }
 
-      auto evdwl = c.template compute_evdwl<STACKPARAMS,TABSTYLE>(rsq,i,j,itype,jtype);
+//    auto evdwl = c.template compute_evdwl<STACKPARAMS,TABSTYLE>(rsq,i,j,itype,jtype);
 
-      double evdwlOld;
-      if (c.isite1 == c.isite2) {
-        evdwlOld = sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwl;
-        evdwl = sqrt(mixWtSite1_i*mixWtSite2_j)*evdwl;
-      } else {
-        evdwlOld = (sqrt(mixWtSite1old_i*mixWtSite2old_j) +
-                    sqrt(mixWtSite2old_i*mixWtSite1old_j))*evdwl;
-        evdwl = (sqrt(mixWtSite1_i*mixWtSite2_j) +
-                 sqrt(mixWtSite2_i*mixWtSite1_j))*evdwl;
-      }
-      evdwlOld *= factor_lj;
-      evdwl *= factor_lj;
+//    double evdwlOld;
+//    if (c.isite1 == c.isite2) {
+//      evdwlOld = sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwl;
+//      evdwl = sqrt(mixWtSite1_i*mixWtSite2_j)*evdwl;
+//    } else {
+//      evdwlOld = (sqrt(mixWtSite1old_i*mixWtSite2old_j) +
+//                  sqrt(mixWtSite2old_i*mixWtSite1old_j))*evdwl;
+//      evdwl = (sqrt(mixWtSite1_i*mixWtSite2_j) +
+//               sqrt(mixWtSite2_i*mixWtSite1_j))*evdwl;
+//    }
+//    evdwlOld *= factor_lj;
+//    evdwl *= factor_lj;
 
-      uCG_i += 0.5*evdwlOld;
-      if (do_half) uCG(j) += 0.5*evdwlOld;
+//    uCG_i += 0.5*evdwlOld;
+//    if (do_half) uCG(j) += 0.5*evdwlOld;
 
-      uCGnew_i += 0.5*evdwl;
-      if (do_half) uCGnew(j) += 0.5*evdwl;
-      evdwl = evdwlOld;
+//    uCGnew_i += 0.5*evdwl;
+//    if (do_half) uCGnew(j) += 0.5*evdwl;
+//    evdwl = evdwlOld;
 
-      ev.evdwl += (do_half ? 1.0 : 0.5)*evdwl;
+//    ev.evdwl += (do_half ? 1.0 : 0.5)*evdwl;
 
-      if (EVFLAG) ev_tally(ev,i,j,evdwl,fpair,delx,dely,delz);
-    }
-  }
+//    if (EVFLAG) ev_tally(ev,i,j,evdwl,fpair,delx,dely,delz);
+//  }
+//}
 
-  uCG(i) += uCG_i;
-  uCGnew(i) += uCGnew_i;
+//uCG(i) += uCG_i;
+//uCGnew(i) += uCGnew_i;
 
-  f(i,0) += fx_i;
-  f(i,1) += fy_i;
-  f(i,2) += fz_i;
+//f(i,0) += fx_i;
+//f(i,1) += fy_i;
+//f(i,2) += fz_i;
 
   return ev;
 }
@@ -209,55 +209,55 @@ ev_tally(EV_FLOAT &ev, const int &i, const int &j,
          const F_FLOAT &epair, const F_FLOAT &fpair, const F_FLOAT &delx,
          const F_FLOAT &dely, const F_FLOAT &delz) const
 {
-  const int EFLAG = c.eflag;
-  const int NEWTON_PAIR = c.newton_pair;
-  const int VFLAG = c.vflag_either;
+//const int EFLAG = c.eflag;
+//const int NEWTON_PAIR = c.newton_pair;
+//const int VFLAG = c.vflag_either;
 
-  if (VFLAG) {
-    const E_FLOAT v0 = delx*delx*fpair;
-    const E_FLOAT v1 = dely*dely*fpair;
-    const E_FLOAT v2 = delz*delz*fpair;
-    const E_FLOAT v3 = delx*dely*fpair;
-    const E_FLOAT v4 = delx*delz*fpair;
-    const E_FLOAT v5 = dely*delz*fpair;
+//if (VFLAG) {
+//  const E_FLOAT v0 = delx*delx*fpair;
+//  const E_FLOAT v1 = dely*dely*fpair;
+//  const E_FLOAT v2 = delz*delz*fpair;
+//  const E_FLOAT v3 = delx*dely*fpair;
+//  const E_FLOAT v4 = delx*delz*fpair;
+//  const E_FLOAT v5 = dely*delz*fpair;
 
-    if (c.vflag_global) {
-      if (NEIGHFLAG!=FULL) {
-        if (NEWTON_PAIR) {
-          ev.v[0] += v0;
-          ev.v[1] += v1;
-          ev.v[2] += v2;
-          ev.v[3] += v3;
-          ev.v[4] += v4;
-          ev.v[5] += v5;
-        } else {
-          if (i < c.nlocal) {
-            ev.v[0] += 0.5*v0;
-            ev.v[1] += 0.5*v1;
-            ev.v[2] += 0.5*v2;
-            ev.v[3] += 0.5*v3;
-            ev.v[4] += 0.5*v4;
-            ev.v[5] += 0.5*v5;
-          }
-          if (j < c.nlocal) {
-            ev.v[0] += 0.5*v0;
-            ev.v[1] += 0.5*v1;
-            ev.v[2] += 0.5*v2;
-            ev.v[3] += 0.5*v3;
-            ev.v[4] += 0.5*v4;
-            ev.v[5] += 0.5*v5;
-          }
-        }
-      } else {
-        ev.v[0] += 0.5*v0;
-        ev.v[1] += 0.5*v1;
-        ev.v[2] += 0.5*v2;
-        ev.v[3] += 0.5*v3;
-        ev.v[4] += 0.5*v4;
-        ev.v[5] += 0.5*v5;
-      }
-    }
-  }
+//  if (c.vflag_global) {
+//    if (NEIGHFLAG!=FULL) {
+//      if (NEWTON_PAIR) {
+//        ev.v[0] += v0;
+//        ev.v[1] += v1;
+//        ev.v[2] += v2;
+//        ev.v[3] += v3;
+//        ev.v[4] += v4;
+//        ev.v[5] += v5;
+//      } else {
+//        if (i < c.nlocal) {
+//          ev.v[0] += 0.5*v0;
+//          ev.v[1] += 0.5*v1;
+//          ev.v[2] += 0.5*v2;
+//          ev.v[3] += 0.5*v3;
+//          ev.v[4] += 0.5*v4;
+//          ev.v[5] += 0.5*v5;
+//        }
+//        if (j < c.nlocal) {
+//          ev.v[0] += 0.5*v0;
+//          ev.v[1] += 0.5*v1;
+//          ev.v[2] += 0.5*v2;
+//          ev.v[3] += 0.5*v3;
+//          ev.v[4] += 0.5*v4;
+//          ev.v[5] += 0.5*v5;
+//        }
+//      }
+//    } else {
+//      ev.v[0] += 0.5*v0;
+//      ev.v[1] += 0.5*v1;
+//      ev.v[2] += 0.5*v2;
+//      ev.v[3] += 0.5*v3;
+//      ev.v[4] += 0.5*v4;
+//      ev.v[5] += 0.5*v5;
+//    }
+//  }
+//}
 }
 
 template<class DeviceType>
@@ -266,8 +266,8 @@ KOKKOS_INLINE_FUNCTION
 void
 PairTableRXKokkos<DeviceType>::Functor<NEIGHFLAG,STACKPARAMS,TABSTYLE>::
 operator()(const int i) const {
-  if (c.newton_pair) compute_item<0,1>(i);
-  else compute_item<0,0>(i);
+//if (c.newton_pair) compute_item<0,1>(i);
+//else compute_item<0,0>(i);
 }
 
 template<class DeviceType>
@@ -276,8 +276,8 @@ KOKKOS_INLINE_FUNCTION
 void
 PairTableRXKokkos<DeviceType>::Functor<NEIGHFLAG,STACKPARAMS,TABSTYLE>::
 operator()(const int i, value_type &energy_virial) const {
-  if (c.newton_pair) energy_virial += compute_item<1,1>(i);
-  else energy_virial += compute_item<1,0>(i);
+//if (c.newton_pair) energy_virial += compute_item<1,1>(i);
+//else energy_virial += compute_item<1,0>(i);
 }
 
 template<class DeviceType>
@@ -322,10 +322,10 @@ void PairTableRXKokkos<DeviceType>::compute_style(int eflag_in, int vflag_in)
 
   typename DAT::t_float_2d_randomread d_dvector = atomKK->k_dvector.view<DeviceType>();
 
-  Kokkos::parallel_for(ntotal, LAMMPS_LAMBDA(int i) {
-    getMixingWeights<DeviceType>(d_dvector, i, mixWtSite1old_(i), mixWtSite2old_(i),
-        mixWtSite1_(i), mixWtSite2_(i));
-  });
+//Kokkos::parallel_for(ntotal, LAMMPS_LAMBDA(int i) {
+//  getMixingWeights<DeviceType>(d_dvector, i, mixWtSite1old_(i), mixWtSite2old_(i),
+//      mixWtSite1_(i), mixWtSite2_(i));
+//});
 
   if (neighflag == N2) error->all(FLERR,"pair table/rx/kk can't handle N2 yet\n");
 
@@ -971,8 +971,6 @@ void PairTableRXKokkos<DeviceType>::getMixingWeights(
     nTotal += dvector(ispecies,id);
     nTotalOld += dvector(ispecies+nspecies,id);
   }
-  if(nTotal < MY_EPSILON || nTotalOld < MY_EPSILON)
-    error->all(FLERR,"The number of molecules in CG particle is less than 10*DBL_EPSILON.");
 
   if (isOneFluid(isite1) == false){
     nMoleculesOld1 = dvector(isite1+nspecies,id);

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -153,8 +153,15 @@ class PairTableRXKokkos : public PairTable {
 
   friend void pair_virial_fdotr_compute<PairTableRXKokkos>(PairTableRXKokkos*);
 
+  /* PairTableRX members */
+
+  int nspecies;
+  char *site1, *site2;
+  int isite1, isite2;
+  bool fractionalWeighting;
+
   KOKKOS_INLINE_FUNCTION
-  void getMixingWeights(typename DAT::t_float_2d_randomread dvector, int, double &, double &, double &, double &);
+  void getMixingWeights(typename DAT::t_float_2d_randomread, int, double &, double &, double &, double &);
 };
 
 }

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -106,39 +106,6 @@ class PairTableRXKokkos : public PairTable {
   int isite1, isite2;
   bool fractionalWeighting;
 
-  /* a duplicate of PairComputeFunctor to deal with uCG */
-  template <int NEIGHFLAG, bool STACKPARAMS, int TABSTYLE>
-  struct Functor {
-    using device_type = DeviceType;
-    typedef EV_FLOAT value_type;
-  //PairTableRXKokkos<device_type> c;
-    // arrays are atomic for Half(Thread) neighbor style
-    Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,
-                 device_type,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > f;
-    Kokkos::View<E_FLOAT*, typename DAT::t_efloat_1d::array_layout,
-                 device_type,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > uCG;
-    Kokkos::View<E_FLOAT*, typename DAT::t_efloat_1d::array_layout,
-                 device_type,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > uCGnew;
-  //NeighListKokkos<device_type> list;
-    Functor(PairTableRXKokkos* c_ptr, NeighListKokkos<device_type>* list_ptr);
-    ~Functor();
-    KOKKOS_INLINE_FUNCTION int sbmask(const int& j) const {
-      return j >> SBBITS & 3;
-    }
-    template<int EVFLAG, int NEWTON_PAIR>
-    KOKKOS_INLINE_FUNCTION
-    EV_FLOAT compute_item(const int&) const;
-    KOKKOS_INLINE_FUNCTION
-    void
-    ev_tally(EV_FLOAT &ev, const int &i, const int &j,
-             const F_FLOAT &epair, const F_FLOAT &fpair, const F_FLOAT &delx,
-             const F_FLOAT &dely, const F_FLOAT &delz) const;
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const int) const;
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const int, value_type&) const;
-  };
-
 };
 
 }

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -132,7 +132,7 @@ class PairTableRXKokkos : public PairTable {
   struct Functor {
     using device_type = DeviceType;
     typedef EV_FLOAT value_type;
-    PairTableRXKokkos c;
+  //PairTableRXKokkos<device_type> c;
     // arrays are atomic for Half(Thread) neighbor style
     Kokkos::View<F_FLOAT*[3], typename DAT::t_f_array::array_layout,
                  device_type,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > f;
@@ -140,7 +140,7 @@ class PairTableRXKokkos : public PairTable {
                  device_type,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > uCG;
     Kokkos::View<E_FLOAT*, typename DAT::t_efloat_1d::array_layout,
                  device_type,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value> > uCGnew;
-    NeighListKokkos<device_type> list;
+  //NeighListKokkos<device_type> list;
     Functor(PairTableRXKokkos* c_ptr, NeighListKokkos<device_type>* list_ptr);
     ~Functor();
     KOKKOS_INLINE_FUNCTION int sbmask(const int& j) const {

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -23,6 +23,7 @@ PairStyle(table/rx/kk/host,PairTableRXKokkos<LMPHostType>)
 #define LMP_PAIR_TABLE_RX_KOKKOS_H
 
 #include "pair_table_kokkos.h"
+#include "kokkos_few.h"
 
 namespace LAMMPS_NS {
 
@@ -78,17 +79,15 @@ class PairTableRXKokkos : public PairTable {
   TableDevice* d_table;
   TableHost* h_table;
 
-  F_FLOAT m_cutsq[MAX_TYPES_STACKPARAMS+1][MAX_TYPES_STACKPARAMS+1];
+  Few<Few<F_FLOAT, MAX_TYPES_STACKPARAMS+1>, MAX_TYPES_STACKPARAMS+1> m_cutsq;
 
   typename ArrayTypes<DeviceType>::t_ffloat_2d d_cutsq;
 
   virtual void allocate();
   void compute_table(Table *);
 
-  typename ArrayTypes<DeviceType>::t_x_array_const c_x;
+  typename ArrayTypes<DeviceType>::t_x_array_randomread x;
   typename ArrayTypes<DeviceType>::t_f_array f;
-  typename ArrayTypes<DeviceType>::t_efloat_1d uCG;
-  typename ArrayTypes<DeviceType>::t_efloat_1d uCGnew;
   typename ArrayTypes<DeviceType>::t_efloat_1d d_eatom;
   typename ArrayTypes<DeviceType>::t_virial_array d_vatom;
 

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -45,7 +45,9 @@ class PairTableRXKokkos : public PairTable {
   void compute_style(int, int);
 
   void settings(int, char **);
+  void coeff(int, char **);
   double init_one(int, int);
+  virtual double single(int, int, int, int, double, double, double, double &);
 
   void init_style();
 
@@ -160,8 +162,10 @@ class PairTableRXKokkos : public PairTable {
   int isite1, isite2;
   bool fractionalWeighting;
 
+  template <class ExecDevice>
   KOKKOS_INLINE_FUNCTION
-  void getMixingWeights(typename DAT::t_float_2d_randomread, int, double &, double &, double &, double &);
+  void getMixingWeights(typename ArrayTypes<ExecDevice>::t_float_2d_randomread,
+      int, double &, double &, double &, double &);
 };
 
 }

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -13,9 +13,9 @@
 
 #ifdef PAIR_CLASS
 
-PairStyle(table/rx/kk,PairTableKokkos<LMPDeviceType>)
-PairStyle(table/rx/kk/device,PairTableKokkos<LMPDeviceType>)
-PairStyle(table/rx/kk/host,PairTableKokkos<LMPHostType>)
+PairStyle(table/rx/kk,PairTableRXKokkos<LMPDeviceType>)
+PairStyle(table/rx/kk/device,PairTableRXKokkos<LMPDeviceType>)
+PairStyle(table/rx/kk/host,PairTableRXKokkos<LMPHostType>)
 
 #else
 

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -92,15 +92,11 @@ class PairTableRXKokkos : public PairTable {
   typename ArrayTypes<DeviceType>::t_efloat_1d d_eatom;
   typename ArrayTypes<DeviceType>::t_virial_array d_vatom;
 
-  int nlocal,nall,eflag,vflag,neighflag,newton_pair;
+  int neighflag;
 
   int update_table;
   void create_kokkos_tables();
   void cleanup_copy();
-
-  template<bool STACKPARAMS, int TABSTYLE>
-  KOKKOS_INLINE_FUNCTION
-  F_FLOAT compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, const int& jtype) const;
 
   friend void pair_virial_fdotr_compute<PairTableRXKokkos>(PairTableRXKokkos*);
 
@@ -110,11 +106,6 @@ class PairTableRXKokkos : public PairTable {
   char *site1, *site2;
   int isite1, isite2;
   bool fractionalWeighting;
-
-  Kokkos::View<double*, DeviceType> mixWtSite1old_;
-  Kokkos::View<double*, DeviceType> mixWtSite2old_;
-  Kokkos::View<double*, DeviceType> mixWtSite1_;
-  Kokkos::View<double*, DeviceType> mixWtSite2_;
 
   /* a duplicate of PairComputeFunctor to deal with uCG */
   template <int NEIGHFLAG, bool STACKPARAMS, int TABSTYLE>

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -85,10 +85,8 @@ class PairTableRXKokkos : public PairTable {
   virtual void allocate();
   void compute_table(Table *);
 
-  typename ArrayTypes<DeviceType>::t_x_array_randomread x;
   typename ArrayTypes<DeviceType>::t_x_array_const c_x;
   typename ArrayTypes<DeviceType>::t_f_array f;
-  typename ArrayTypes<DeviceType>::t_int_1d_randomread type;
   typename ArrayTypes<DeviceType>::t_efloat_1d uCG;
   typename ArrayTypes<DeviceType>::t_efloat_1d uCGnew;
   typename ArrayTypes<DeviceType>::t_efloat_1d d_eatom;
@@ -116,11 +114,6 @@ class PairTableRXKokkos : public PairTable {
   char *site1, *site2;
   int isite1, isite2;
   bool fractionalWeighting;
-
-  template <class ExecDevice>
-  KOKKOS_INLINE_FUNCTION
-  void getMixingWeights(typename ArrayTypes<ExecDevice>::t_float_2d_randomread,
-      int, double &, double &, double &, double &);
 
   Kokkos::View<double*, DeviceType> mixWtSite1old_;
   Kokkos::View<double*, DeviceType> mixWtSite2old_;

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -102,11 +102,11 @@ class PairTableRXKokkos : public PairTable {
   void create_kokkos_tables();
   void cleanup_copy();
 
-  template<bool STACKPARAMS, class Specialisation>
+  template<bool STACKPARAMS, int TABSTYLE>
   KOKKOS_INLINE_FUNCTION
   F_FLOAT compute_fpair(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, const int& jtype) const;
 
-  template<bool STACKPARAMS, class Specialisation>
+  template<bool STACKPARAMS, int TABSTYLE>
   KOKKOS_INLINE_FUNCTION
   F_FLOAT compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, const int& jtype) const;
 
@@ -150,12 +150,12 @@ class PairTableRXKokkos : public PairTable {
     }
     template<int EVFLAG, int NEWTON_PAIR>
     KOKKOS_INLINE_FUNCTION
-    EV_FLOAT compute_item(const int&,
-                          const NeighListKokkos<device_type>&, const NoCoulTag&) const;
+    EV_FLOAT compute_item(const int&) const;
     KOKKOS_INLINE_FUNCTION
+    void
     ev_tally(EV_FLOAT &ev, const int &i, const int &j,
              const F_FLOAT &epair, const F_FLOAT &fpair, const F_FLOAT &delx,
-             const F_FLOAT &dely, const F_FLOAT &delz) const
+             const F_FLOAT &dely, const F_FLOAT &delz) const;
     KOKKOS_INLINE_FUNCTION
     void operator()(const int) const;
     KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -92,6 +92,8 @@ class PairTableRXKokkos : public PairTable {
   typename ArrayTypes<DeviceType>::t_x_array_const c_x;
   typename ArrayTypes<DeviceType>::t_f_array f;
   typename ArrayTypes<DeviceType>::t_int_1d_randomread type;
+  typename ArrayTypes<DeviceType>::t_efloat_1d uCG;
+  typename ArrayTypes<DeviceType>::t_efloat_1d uCGnew;
   typename ArrayTypes<DeviceType>::t_efloat_1d d_eatom;
   typename ArrayTypes<DeviceType>::t_virial_array d_vatom;
 

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -30,6 +30,8 @@ template<class DeviceType>
 class PairTableRXKokkos : public PairTable {
  public:
 
+  using DAT = ArrayTypes<DeviceType>;
+
   enum {EnabledNeighFlags=FULL|HALFTHREAD|HALF|N2};
   enum {COUL_FLAG=0};
   typedef DeviceType device_type;
@@ -150,6 +152,9 @@ class PairTableRXKokkos : public PairTable {
   friend class PairComputeFunctor<PairTableRXKokkos,N2,false,S_TableCompute<DeviceType,BITMAP> >;
 
   friend void pair_virial_fdotr_compute<PairTableRXKokkos>(PairTableRXKokkos*);
+
+  KOKKOS_INLINE_FUNCTION
+  void getMixingWeights(typename DAT::t_float_2d_randomread dvector, int, double &, double &, double &, double &);
 };
 
 }

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -50,9 +50,6 @@ class PairTableRXKokkos : public PairTable {
 
   void init_style();
 
-
- protected:
-
   struct TableDeviceConst {
     typename ArrayTypes<DeviceType>::t_ffloat_2d cutsq;
     typename ArrayTypes<DeviceType>::t_int_2d tabindex;
@@ -97,7 +94,6 @@ class PairTableRXKokkos : public PairTable {
   typename ArrayTypes<DeviceType>::t_efloat_1d d_eatom;
   typename ArrayTypes<DeviceType>::t_virial_array d_vatom;
 
- protected:
   int nlocal,nall,eflag,vflag,neighflag,newton_pair;
 
   int update_table;
@@ -163,6 +159,7 @@ class PairTableRXKokkos : public PairTable {
     KOKKOS_INLINE_FUNCTION
     void operator()(const int, value_type&) const;
   };
+
 };
 
 }

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -100,10 +100,6 @@ class PairTableRXKokkos : public PairTable {
 
   template<bool STACKPARAMS, int TABSTYLE>
   KOKKOS_INLINE_FUNCTION
-  F_FLOAT compute_fpair(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, const int& jtype) const;
-
-  template<bool STACKPARAMS, int TABSTYLE>
-  KOKKOS_INLINE_FUNCTION
   F_FLOAT compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, const int& jtype) const;
 
   friend void pair_virial_fdotr_compute<PairTableRXKokkos>(PairTableRXKokkos*);

--- a/src/KOKKOS/pair_table_rx_kokkos.h
+++ b/src/KOKKOS/pair_table_rx_kokkos.h
@@ -166,6 +166,11 @@ class PairTableRXKokkos : public PairTable {
   KOKKOS_INLINE_FUNCTION
   void getMixingWeights(typename ArrayTypes<ExecDevice>::t_float_2d_randomread,
       int, double &, double &, double &, double &);
+
+  Kokkos::View<double*, DeviceType> mixWtSite1old_;
+  Kokkos::View<double*, DeviceType> mixWtSite2old_;
+  Kokkos::View<double*, DeviceType> mixWtSite1_;
+  Kokkos::View<double*, DeviceType> mixWtSite2_;
 };
 
 }

--- a/src/pair.h
+++ b/src/pair.h
@@ -211,10 +211,12 @@ class Pair : protected Pointers {
   double tabinner;                     // inner cutoff for Coulomb table
   double tabinner_disp;                 // inner cutoff for dispersion table
 
+ public:
   // custom data type for accessing Coulomb tables
 
   typedef union {int i; float f;} union_int_float_t;
 
+ protected:
   int vflag_fdotr;
   int maxeatom,maxvatom;
 

--- a/src/pair_table.h
+++ b/src/pair_table.h
@@ -40,9 +40,9 @@ class PairTable : public Pair {
   virtual double single(int, int, int, int, double, double, double, double &);
   void *extract(const char *, int &);
 
- protected:
   enum{LOOKUP,LINEAR,SPLINE,BITMAP};
 
+ protected:
   int tabstyle,tablength;
   struct Table {
     int ninput,rflag,fpflag,match,ntablebits;


### PR DESCRIPTION
This PR provides a Kokkos version of user-dpd's pair_table_rx. Due to the use of uCG and uCGnew variables, I don't use the pair_kokkos.h framework. Furthermore, due to increasing complications with lambdas, I do not copy the pair class itself to the device, but rather extract all necessary Kokkos Views and pass them to free functions. Finally, a couple things in the core of LAMMPS had to be made more visible so they could be used from free functions.

@stanmoore1 