### PR TITLE
USER-DPD fixleaks

### DIFF
--- a/src/KOKKOS/npair_ssa_kokkos.cpp
+++ b/src/KOKKOS/npair_ssa_kokkos.cpp
@@ -122,8 +122,8 @@ void NPairSSAKokkos<DeviceType>::copy_stencil_info()
   NStencilSSA *ns_ssa = dynamic_cast<NStencilSSA*>(ns);
   if (!ns_ssa) error->one(FLERR, "NStencil wasn't a NStencilSSA object");
 
-  k_nstencil_ssa = DAT::tdual_int_1d("NPairSSAKokkos:nstencil_ssa",8);
-  for (int k = 0; k < 8; ++k) {
+  k_nstencil_ssa = DAT::tdual_int_1d("NPairSSAKokkos:nstencil_ssa",5);
+  for (int k = 0; k < 5; ++k) {
     k_nstencil_ssa.h_view(k) = ns_ssa->nstencil_ssa[k];
   }
   k_nstencil_ssa.modify<LMPHostType>();

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -208,6 +208,7 @@ void ReadRestart::command(int narg, char **arg)
     mpiio->read((headerOffset+assignedChunkOffset),assignedChunkSize,buf);
     mpiio->close();
 
+    if (assignedChunkSize > atom->nmax) avec->grow(assignedChunkSize);
     m = 0;
     while (m < assignedChunkSize) m += avec->unpack_restart(&buf[m]);
   }


### PR DESCRIPTION
Stan,
Please check if this fixes some of the problems reported by Valgrind.
As stated in my email, this branch doesn't yet address the memory leak of the "firstneigh"
array that gets allocated in the grow() method at line 64 of neigh_list_kokkos.cpp.