### PR TITLE
fix memory leak via NeighListKokkos::clean_copy()

### DIFF
--- a/src/KOKKOS/fix_qeq_reax_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reax_kokkos.cpp
@@ -217,8 +217,6 @@ void FixQEqReaxKokkos<DeviceType>::pre_force(int vflag)
   d_ilist = k_list->d_ilist;
   inum = list->inum;
 
-  k_list->clean_copy();
-  //cleanup_copy();
   copymode = 1;
 
   int teamsize = TEAMSIZE;

--- a/src/KOKKOS/fix_shardlow_kokkos.cpp
+++ b/src/KOKKOS/fix_shardlow_kokkos.cpp
@@ -624,8 +624,6 @@ void FixShardlowKokkos<DeviceType>::initial_integrate(int vflag)
   d_neighbors = k_list->d_neighbors;
   d_ilist = k_list->d_ilist;
 
-  k_list->clean_copy();
-  //cleanup_copy();
   copymode = 1;
 
   dtsqrt = sqrt(update->dt);

--- a/src/KOKKOS/neigh_list_kokkos.cpp
+++ b/src/KOKKOS/neigh_list_kokkos.cpp
@@ -22,21 +22,14 @@ enum{NSQ,BIN,MULTI};
 /* ---------------------------------------------------------------------- */
 
 template<class Device>
-void NeighListKokkos<Device>::clean_copy()
+NeighListKokkos<Device>::NeighListKokkos(class LAMMPS *lmp):NeighList(lmp)
 {
-  ilist = NULL;
-  numneigh = NULL;
-  firstneigh = NULL;
-  firstdouble = NULL;
-  dnum = 0;
-  iskip = NULL;
-  ijskip = NULL;
-
-  ipage = NULL;
-  dpage = NULL;
-
+  _stride = 1;
+  maxneighs = 16;
+  kokkos = 1;
   maxatoms = 0;
-}
+  execution_space = ExecutionSpaceFromDevice<Device>::space;
+};
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/neigh_list_kokkos.h
+++ b/src/KOKKOS/neigh_list_kokkos.h
@@ -68,18 +68,13 @@ class NeighListKokkos: public NeighList {
 public:
   int maxneighs;
 
-  void clean_copy();
   void grow(int nmax);
   typename ArrayTypes<Device>::t_neighbors_2d d_neighbors;
   typename DAT::tdual_int_1d k_ilist;   // local indices of I atoms
   typename ArrayTypes<Device>::t_int_1d d_ilist;
   typename ArrayTypes<Device>::t_int_1d d_numneigh; // # of J neighs for each I
 
-  NeighListKokkos(class LAMMPS *lmp):
-  NeighList(lmp) {_stride = 1; maxneighs = 16; kokkos = 1; maxatoms = 0;
-                  execution_space = ExecutionSpaceFromDevice<Device>::space;
-  };
-  ~NeighListKokkos() {numneigh = NULL; ilist = NULL;};
+  NeighListKokkos(class LAMMPS *lmp);
 
   KOKKOS_INLINE_FUNCTION
   AtomNeighbors get_neighbors(const int &i) const {

--- a/src/KOKKOS/npair_kokkos.h
+++ b/src/KOKKOS/npair_kokkos.h
@@ -265,7 +265,7 @@ class NeighborKokkosExecute
     h_new_maxneighs() = neigh_list.maxneighs;
   };
 
-  ~NeighborKokkosExecute() {neigh_list.clean_copy();};
+  ~NeighborKokkosExecute() {neigh_list.copymode = 1;};
 
   template<int HalfNeigh, int Newton, int Tri>
   KOKKOS_FUNCTION

--- a/src/KOKKOS/npair_ssa_kokkos.h
+++ b/src/KOKKOS/npair_ssa_kokkos.h
@@ -287,7 +287,7 @@ class NPairSSAKokkosExecute
     h_new_maxneighs() = neigh_list.maxneighs;
   };
 
-  ~NPairSSAKokkosExecute() {neigh_list.clean_copy();};
+  ~NPairSSAKokkosExecute() {neigh_list.copymode = 1;};
 
   void build_locals();
   void build_ghosts();

--- a/src/KOKKOS/pair_coul_dsf_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_dsf_kokkos.cpp
@@ -120,9 +120,6 @@ void PairCoulDSFKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   int inum = list->inum;
 
-  // Call cleanup_copy which sets allocations NULL which are destructed by the PairStyle
-
-  k_list->clean_copy();
   copymode = 1;
 
   // loop over neighbors of my atoms

--- a/src/KOKKOS/pair_coul_wolf_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_wolf_kokkos.cpp
@@ -121,9 +121,6 @@ void PairCoulWolfKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   int inum = list->inum;
 
-  // Call cleanup_copy which sets allocations NULL which are destructed by the PairStyle
-
-  k_list->clean_copy();
   copymode = 1;
 
   // loop over neighbors of my atoms

--- a/src/KOKKOS/pair_eam_alloy_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_alloy_kokkos.cpp
@@ -122,9 +122,6 @@ void PairEAMAlloyKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   d_ilist = k_list->d_ilist;
   int inum = list->inum;
 
-  // Call cleanup_copy which sets allocations NULL which are destructed by the PairStyle
-
-  k_list->clean_copy();
   copymode = 1;
 
   // zero out density

--- a/src/KOKKOS/pair_eam_fs_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_fs_kokkos.cpp
@@ -122,9 +122,6 @@ void PairEAMFSKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   d_ilist = k_list->d_ilist;
   int inum = list->inum;
 
-  // Call cleanup_copy which sets allocations NULL which are destructed by the PairStyle
-
-  k_list->clean_copy();
   copymode = 1;
 
   // zero out density

--- a/src/KOKKOS/pair_eam_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_kokkos.cpp
@@ -117,9 +117,6 @@ void PairEAMKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   d_ilist = k_list->d_ilist;
   int inum = list->inum;
 
-  // Call cleanup_copy which sets allocations NULL which are destructed by the PairStyle
-
-  k_list->clean_copy();
   copymode = 1;
 
   // zero out density

--- a/src/KOKKOS/pair_kokkos.h
+++ b/src/KOKKOS/pair_kokkos.h
@@ -87,7 +87,7 @@ struct PairComputeFunctor  {
   vatom(c.d_vatom),list(*list_ptr) {};
 
   // Call cleanup_copy which sets allocations NULL which are destructed by the PairStyle
-  ~PairComputeFunctor() {c.cleanup_copy();list.clean_copy();};
+  ~PairComputeFunctor() {c.cleanup_copy();list.copymode = 1;};
 
   KOKKOS_INLINE_FUNCTION int sbmask(const int& j) const {
     return j >> SBBITS & 3;
@@ -344,7 +344,7 @@ struct PairComputeFunctor<PairStyle,N2,STACKPARAMS,Specialisation>  {
   PairComputeFunctor(PairStyle* c_ptr,
                           NeighListKokkos<device_type>* list_ptr):
   c(*c_ptr),list(*list_ptr) {};
-  ~PairComputeFunctor() {c.cleanup_copy();list.clean_copy();};
+  ~PairComputeFunctor() {c.cleanup_copy();list.copymode = 1;};
 
   KOKKOS_INLINE_FUNCTION int sbmask(const int& j) const {
     return j >> SBBITS & 3;

--- a/src/KOKKOS/pair_reax_c_kokkos.cpp
+++ b/src/KOKKOS/pair_reax_c_kokkos.cpp
@@ -709,8 +709,6 @@ void PairReaxCKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   d_neighbors = k_list->d_neighbors;
   d_ilist = k_list->d_ilist;
 
-  k_list->clean_copy();
-
   if (eflag_global) {
     for (int i = 0; i < 14; i++)
       pvector[i] = 0.0;
@@ -4012,7 +4010,6 @@ void PairReaxCKokkos<DeviceType>::FindBond(int &numbonds)
   const int inum = list->inum;
   NeighListKokkos<DeviceType>* k_list = static_cast<NeighListKokkos<DeviceType>*>(list);
   d_ilist = k_list->d_ilist;
-  k_list->clean_copy();
 
   numbonds = 0;
   PairReaxCKokkosFindBondFunctor<DeviceType> find_bond_functor(this);

--- a/src/KOKKOS/pair_sw_kokkos.cpp
+++ b/src/KOKKOS/pair_sw_kokkos.cpp
@@ -115,7 +115,6 @@ void PairSWKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   d_numneigh = k_list->d_numneigh;
   d_neighbors = k_list->d_neighbors;
 
-  k_list->clean_copy();
   copymode = 1;
 
   EV_FLOAT ev;

--- a/src/KOKKOS/pair_tersoff_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_kokkos.cpp
@@ -200,7 +200,6 @@ void PairTersoffKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   d_neighbors = k_list->d_neighbors;
   d_ilist = k_list->d_ilist;
 
-  k_list->clean_copy();
   copymode = 1;
 
   EV_FLOAT ev;

--- a/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
@@ -200,7 +200,6 @@ void PairTersoffMODKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   d_neighbors = k_list->d_neighbors;
   d_ilist = k_list->d_ilist;
 
-  k_list->clean_copy();
   copymode = 1;
 
   EV_FLOAT ev;

--- a/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
@@ -214,7 +214,6 @@ void PairTersoffZBLKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   d_neighbors = k_list->d_neighbors;
   d_ilist = k_list->d_ilist;
 
-  k_list->clean_copy();
   copymode = 1;
 
   EV_FLOAT ev;

--- a/src/neigh_list.cpp
+++ b/src/neigh_list.cpp
@@ -48,6 +48,7 @@ NeighList::NeighList(LAMMPS *lmp) : Pointers(lmp)
   ghost = 0;
   ssa = 0;
   copy = 0;
+  copymode = 0;
   dnum = 0;
 
   // ptrs
@@ -86,6 +87,7 @@ NeighList::NeighList(LAMMPS *lmp) : Pointers(lmp)
 
 NeighList::~NeighList()
 {
+  if (copymode) return;
   if (!copy) {
     memory->destroy(ilist);
     memory->destroy(numneigh);

--- a/src/neigh_list.h
+++ b/src/neigh_list.h
@@ -34,7 +34,8 @@ class NeighList : protected Pointers {
   int occasional;                  // 0 if build every reneighbor, 1 if not
   int ghost;                       // 1 if list stores neighbors of ghosts
   int ssa;                         // 1 if list stores Shardlow data
-  int copy;                        // 1 if this list copied from another list
+  int copy;                        // 1 if this list is (host) copied from another list
+  int copymode;                    // 1 if this is a Kokkos on-device copy
   int dnum;                        // # of doubles per neighbor, 0 if none
 
   // data structs to store neighbor pairs I,J and associated values


### PR DESCRIPTION
There were several clean_copy() calls in pair
styles *outside device code*.
They seem to have been left over from an abandoned
effort to copy the Kokkos neighbor list as
a member of the pair style, instead of copying
out the individual views needed.
These leftover clean_copy() calls were setting
pointers to NULL that had not been freed,
leading to large memory leaks.
I've removed the clean_copy() function entirely,
and replaced it with the copymode flag system used
in many other Kokkos objects.
The copymode flag is only set to one in
functors that hold copies of the neighbor list.

@stanmoore1 